### PR TITLE
Inner

### DIFF
--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -327,10 +327,9 @@ class NamespaceManager(object):
 
         if not uri in self.__cache:
             name = None
-            for prefix, namespace in self.ordered_prefixnames:
+            for lennamespace, prefix, namespace in self.ordered_prefixnames:
                 if namespace in uri:
-                    name = uri[len(namespace):]
-                    #name = uri.split(namespace, 1)[1]
+                    name = uri[-lennamespace:]
                     break
 
             if name is None:
@@ -406,7 +405,7 @@ class NamespaceManager(object):
                                                               # prefix
                     self.store.bind(prefix, namespace)
 
-        self.ordered_prefixnames = sorted(self.namespaces(), key=lambda l: -len(l[1]))
+        self.ordered_prefixnames = sorted((-len(n), p, n) for p, n in self.namespaces())
 
     def namespaces(self):
         for prefix, namespace in self.store.namespaces():

--- a/rdflib/namespace.py
+++ b/rdflib/namespace.py
@@ -329,7 +329,8 @@ class NamespaceManager(object):
             name = None
             for prefix, namespace in self.ordered_prefixnames:
                 if namespace in uri:
-                    name = uri.split(namespace, 1)[1]
+                    name = uri[len(namespace):]
+                    #name = uri.split(namespace, 1)[1]
                     break
 
             if name is None:


### PR DESCRIPTION
Merge changes that remove the inner loop in compute_qname and removes calls to stores (which might be remote) from that loop.

Below are the results from a test run of [rdflib_profile](https://github.com/tgbugs/pyontutils/blob/4b671978b35d42c3ec1c44a3da51aaea7981c087/rdflib_profile.py).
```python
# average cumtime
[{'35_rdflib_tgbugs_inner': 0.047816399999999995,
  '35_rdflib_tgbugs_master': 0.05084760000000001,
  '35_rdflib_upstream': 0.0821108},
 {'35_rdflib_tgbugs_inner': 1.1477082999999997,
  '35_rdflib_tgbugs_master': 1.1378062000000002,
  '35_rdflib_upstream': 1.2118622},
 {'35_rdflib_tgbugs_inner': 0.41938810000000004,
  '35_rdflib_tgbugs_master': 0.41990810000000006,
  '35_rdflib_upstream': 2.1135877}]

# full data
{'35_rdflib_tgbugs_inner': [['NIF-Chemical.ttl',
   ('namespace.py', 'compute_qname'),
   [(10180, 10180, 0.014494, 0.049879),
    (10180, 10180, 0.013864999999999999, 0.048007),
    (10180, 10180, 0.01372, 0.046979),
    (10180, 10180, 0.014003999999999999, 0.047175999999999996),
    (10180, 10180, 0.013973, 0.048032),
    (10180, 10180, 0.013611, 0.047027),
    (10180, 10180, 0.013887, 0.047922),
    (10180, 10180, 0.013901, 0.047524),
    (10180, 10180, 0.014015, 0.048187),
    (10180, 10180, 0.013699, 0.047431)]],
  ['NIF-Molecule.ttl',
   ('namespace.py', 'compute_qname'),
   [(246680, 246680, 0.334793, 1.144305),
    (246680, 246680, 0.332061, 1.12991),
    (246680, 246680, 0.335665, 1.140158),
    (246680, 246680, 0.336225, 1.1507859999999999),
    (246680, 246680, 0.33594799999999997, 1.1465589999999999),
    (246680, 246680, 0.336896, 1.154939),
    (246680, 246680, 0.338647, 1.1585779999999999),
    (246680, 246680, 0.337949, 1.1482919999999999),
    (246680, 246680, 0.33359, 1.136202),
    (246680, 246680, 0.34236099999999997, 1.167354)]],
  ['prefix_test',
   ('namespace.py', 'compute_qname'),
   [(103896, 103896, 0.12128399999999999, 0.429278),
    (103896, 103896, 0.11785699999999999, 0.42303999999999997),
    (103896, 103896, 0.11762199999999999, 0.41739899999999996),
    (103896, 103896, 0.11810599999999999, 0.419883),
    (103896, 103896, 0.117493, 0.42267),
    (103896, 103896, 0.116474, 0.41673099999999996),
    (103896, 103896, 0.115228, 0.41570399999999996),
    (103896, 103896, 0.11688799999999999, 0.418554),
    (103896, 103896, 0.116157, 0.414911),
    (103896, 103896, 0.115517, 0.415711)]]],
 '35_rdflib_tgbugs_master': [['NIF-Chemical.ttl',
   ('namespace.py', 'compute_qname'),
   [(10180, 10180, 0.014504, 0.051452),
    (10180, 10180, 0.014459, 0.050852999999999995),
    (10180, 10180, 0.014371, 0.050512999999999995),
    (10180, 10180, 0.014234, 0.050266),
    (10180, 10180, 0.014065, 0.050227999999999995),
    (10180, 10180, 0.014936, 0.053138),
    (10180, 10180, 0.013883999999999999, 0.049793),
    (10180, 10180, 0.014487, 0.050637999999999996),
    (10180, 10180, 0.014322999999999999, 0.050220999999999995),
    (10180, 10180, 0.014509, 0.051373999999999996)]],
  ['NIF-Molecule.ttl',
   ('namespace.py', 'compute_qname'),
   [(246680, 246680, 0.32985, 1.14954),
    (246680, 246680, 0.329586, 1.138905),
    (246680, 246680, 0.327499, 1.1320729999999999),
    (246680, 246680, 0.321113, 1.124939),
    (246680, 246680, 0.326872, 1.1387019999999999),
    (246680, 246680, 0.326992, 1.136935),
    (246680, 246680, 0.32683799999999996, 1.1387939999999999),
    (246680, 246680, 0.326517, 1.1312039999999999),
    (246680, 246680, 0.327884, 1.140655),
    (246680, 246680, 0.330049, 1.146315)]],
  ['prefix_test',
   ('namespace.py', 'compute_qname'),
   [(103896, 103896, 0.11817899999999999, 0.42158999999999996),
    (103896, 103896, 0.11738599999999999, 0.42027899999999996),
    (103896, 103896, 0.11605199999999999, 0.419016),
    (103896, 103896, 0.11664999999999999, 0.419535),
    (103896, 103896, 0.114823, 0.41325799999999996),
    (103896, 103896, 0.11621899999999999, 0.417527),
    (103896, 103896, 0.1158, 0.41927499999999995),
    (103896, 103896, 0.11604199999999999, 0.41820999999999997),
    (103896, 103896, 0.118946, 0.427398),
    (103896, 103896, 0.117542, 0.422993)]]],
 '35_rdflib_upstream': [['NIF-Chemical.ttl',
   ('namespace.py', 'compute_qname'),
   [(10180, 10180, 0.018061, 0.081564),
    (10180, 10180, 0.018132, 0.081595),
    (10180, 10180, 0.018723, 0.08367899999999999),
    (10180, 10180, 0.018829, 0.086569),
    (10180, 10180, 0.017925, 0.08080799999999999),
    (10180, 10180, 0.017924, 0.081144),
    (10180, 10180, 0.017775, 0.08001799999999999),
    (10180, 10180, 0.017882, 0.080825),
    (10180, 10180, 0.01843, 0.08373699999999999),
    (10180, 10180, 0.017953999999999998, 0.08116899999999999)]],
  ['NIF-Molecule.ttl',
   ('namespace.py', 'compute_qname'),
   [(246680, 246680, 0.340068, 1.216165),
    (246680, 246680, 0.336315, 1.2061469999999999),
    (246680, 246680, 0.340232, 1.213006),
    (246680, 246680, 0.33802299999999996, 1.2050699999999999),
    (246680, 246680, 0.338074, 1.211879),
    (246680, 246680, 0.34141499999999997, 1.219474),
    (246680, 246680, 0.338951, 1.2088189999999999),
    (246680, 246680, 0.34032, 1.211751),
    (246680, 246680, 0.34183399999999997, 1.216853),
    (246680, 246680, 0.3383, 1.209458)]],
  ['prefix_test',
   ('namespace.py', 'compute_qname'),
   [(103896, 103896, 0.27138, 2.0928679999999997),
    (103896, 103896, 0.27274899999999996, 2.0995019999999998),
    (103896, 103896, 0.273768, 2.100132),
    (103896, 103896, 0.27585699999999996, 2.111371),
    (103896, 103896, 0.27530499999999997, 2.125223),
    (103896, 103896, 0.279532, 2.146899),
    (103896, 103896, 0.27416599999999997, 2.100225),
    (103896, 103896, 0.275318, 2.118808),
    (103896, 103896, 0.279235, 2.140654),
    (103896, 103896, 0.272544, 2.100195)]]]}
```